### PR TITLE
Remove the CORS filter in the API Gateway

### DIFF
--- a/src/main/java/com/hedvig/gateway/GatewayApplication.java
+++ b/src/main/java/com/hedvig/gateway/GatewayApplication.java
@@ -11,11 +11,6 @@ import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
-
-import java.util.TreeMap;
 
 @EnableZuulProxy
 @SpringBootApplication
@@ -44,21 +39,6 @@ public class GatewayApplication {
 	@Bean
 	public RestTemplate restTemplate() {
     	return new RestTemplate();
-	}
-
-	@Bean
-	public CorsFilter corsFilter() {
-		final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		final CorsConfiguration config = new CorsConfiguration();
-		config.addAllowedOrigin("*");
-		config.addAllowedMethod("GET");
-		config.addAllowedMethod("POST");
-		config.setMaxAge(3000l);
-		config.addAllowedHeader("Authorization");
-		config.addAllowedHeader("Content-Type");
-		config.addExposedHeader("location");
-		source.registerCorsConfiguration("/**", config);
-		return new CorsFilter(source);
 	}
 
 	/*


### PR DESCRIPTION
This is a security issue which we do not need to have anymore.